### PR TITLE
Make HTTP methods uppercase

### DIFF
--- a/get-hal-forms-example.json
+++ b/get-hal-forms-example.json
@@ -24,7 +24,7 @@
   "_templates" : {
     "default" : {
       "title" : "Filter",
-      "method":"get",
+      "method":"GET",
       "properties": [
         {"name":"title", "value":"", "prompt":"Title"},
         {"name":"completed", "value":"", "prompt":"Completed", "regex":"^(true|false)$"}

--- a/hal-forms-response.json
+++ b/hal-forms-response.json
@@ -7,7 +7,7 @@
   "_templates" : {
     "default" : {
       "title" : "Create",
-      "method" : "post",
+      "method" : "POST",
       "contentType" : "application/json",
       "properties" : [
         {"name" : "title", "required" : true, "value" : "", "prompt" : "Title", "regex" : "", "templated" : false},

--- a/index.html
+++ b/index.html
@@ -850,7 +850,7 @@ interpreted as described in <a href="http://tools.ietf.org/html/rfc2119">RFC2119
   "_templates" : {
     "default" : {
       "title" : "Create",
-      "method" : "post",
+      "method" : "POST",
       "contentType" : "application/json",
       "properties" : [
         {"name" : "title", "required" : true, "value" : "", "prompt" : "Title", "regex" : "", "templated" : false},
@@ -1032,7 +1032,7 @@ A human-readable string that can be used to identify this template. This is a va
   "_templates" : {
     "default" : {
       "title" : "Filter",
-      "method":"get",
+      "method":"GET",
       "properties": [
         {"name":"title", "value":"", "prompt":"Title"},
         {"name":"completed", "value":"", "prompt":"Completed", "regex":"^(true|false)$"}


### PR DESCRIPTION
HTTP methods are case sensitive. Better use the correct case.
The spec could define that they should be treated case insensitive but in general it is better to use the correct case.