### PR TITLE
Update HAL spec links to the latest draft

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1890,7 +1890,7 @@ All new properties or objects are treated as OPTIONAL (e.g. no new REQUIRED elem
 </li>
 <li>
 <p>
-<a id="hal-spec"></a> [HALSPEC] Kelly, M. "JSON Hypertext Application Language" (Draft), July 2015 <a href="https://tools.ietf.org/html/draft-kelly-json-hal-07">https://tools.ietf.org/html/draft-kelly-json-hal-07</a>
+<a id="hal-spec"></a> [HALSPEC] Kelly, M. "JSON Hypertext Application Language" (Draft), May 2016 <a href="https://tools.ietf.org/html/draft-kelly-json-hal-07">https://tools.ietf.org/html/draft-kelly-json-hal</a>
 </p>
 </li>
 <li>

--- a/index.asciidoc
+++ b/index.asciidoc
@@ -832,7 +832,7 @@ Authors should be aware that a future version of this specification MAY add new 
 
 == References
  * [[hal]] [HAL] Kelly, M. "HAL - Hypertext Application Language", September 2013, http://stateless.co/hal_specification.html
- * [[hal-spec]] [HALSPEC] Kelly, M. "JSON Hypertext Application Language" (Draft), July 2015 https://tools.ietf.org/html/draft-kelly-json-hal-07
+ * [[hal-spec]] [HALSPEC] Kelly, M. "JSON Hypertext Application Language" (Draft), May 2016 https://tools.ietf.org/html/draft-kelly-json-hal
  * [[repo]] [REPO] Github, "HAL-FORMS", https://github.com/RWCBook/hal-forms
  * [[rfc2119]] [RFC2119] Bradner, S.,"Key words for use in RFCs to Indicate Requirement Levels", March 1997, http://tools.ietf.org/html/rfc2119
  * [[rfc7159]] [RFC7159] Bray, T. "The JavaScript Object Notation (JSON) Data Interchange Format", March 2014, https://tools.ietf.org/html/rfc7159

--- a/index.html
+++ b/index.html
@@ -1890,7 +1890,7 @@ All new properties or objects are treated as OPTIONAL (e.g. no new REQUIRED elem
 </li>
 <li>
 <p>
-<a id="hal-spec"></a> [HALSPEC] Kelly, M. "JSON Hypertext Application Language" (Draft), July 2015 <a href="https://tools.ietf.org/html/draft-kelly-json-hal-07">https://tools.ietf.org/html/draft-kelly-json-hal-07</a>
+<a id="hal-spec"></a> [HALSPEC] Kelly, M. "JSON Hypertext Application Language" (Draft), May 2016 <a href="https://tools.ietf.org/html/draft-kelly-json-hal">https://tools.ietf.org/html/draft-kelly-json-hal</a>
 </p>
 </li>
 <li>


### PR DESCRIPTION
The HAL-FORMS spec currently links to an older draft of HAL spec.

This PR updates all the links to point to the current draft of HAL spec.